### PR TITLE
Handle default empty filter in setFilter function

### DIFF
--- a/lib/ro-filter-parser.js
+++ b/lib/ro-filter-parser.js
@@ -115,7 +115,7 @@ export function setFilter(definition, { label, subtype, values }) {
     }
   }
   const convertedFilter = parsedFilter.length ? parsedFilter : sivIncluded;
-  return convertObjectToString(convertedFilter);
+  return convertedFilter ? convertObjectToString(convertedFilter) : 'SIV_ATTRIBUTE(id)==[0]';
 }
 
 export function addToFilter(definition, { label, subtype, values }) {

--- a/lib/util/object-to-string.js
+++ b/lib/util/object-to-string.js
@@ -1,5 +1,5 @@
 // Coz flatMap seems to be implemented only in Node11
-import { flatten, isNil } from 'ramda';
+import { flatten } from 'ramda';
 
 /**
  * This function consumes a filter as a JSON object and returns the filter string representation
@@ -12,9 +12,6 @@ import { flatten, isNil } from 'ramda';
  * returns: `SIV_ATTRIBUTE(id)==[123]`
  */
 export default function convertObjectToString(filter) {
-  if (isNil(filter)) {
-    return null;
-  }
   if (filter && filter.constructor === Array) {
     return filter.map(f => `${convertObjectToString(f)}`).join('|');
   }

--- a/lib/util/object-to-string.js
+++ b/lib/util/object-to-string.js
@@ -1,5 +1,5 @@
 // Coz flatMap seems to be implemented only in Node11
-import { flatten } from 'ramda';
+import { flatten, isNil } from 'ramda';
 
 /**
  * This function consumes a filter as a JSON object and returns the filter string representation
@@ -8,11 +8,11 @@ import { flatten } from 'ramda';
  * @param {object} filter
  * @returns {string} The filter in a string representation
  * @example
- * convertObjectToString({SIV_ATTRIBUTE: {id: included: [123]}})
+ * convertObjectToString({SIV_ATTRIBUTE: {id: {included: [123]}}})
  * returns: `SIV_ATTRIBUTE(id)==[123]`
  */
 export default function convertObjectToString(filter) {
-  if (filter === null) {
+  if (isNil(filter)) {
     return null;
   }
   if (filter && filter.constructor === Array) {

--- a/lib/util/object-to-string.js
+++ b/lib/util/object-to-string.js
@@ -12,10 +12,13 @@ import { flatten } from 'ramda';
  * returns: `SIV_ATTRIBUTE(id)==[123]`
  */
 export default function convertObjectToString(filter) {
-  if (filter.constructor === Array) {
+  if (filter === null) {
+    return null;
+  }
+  if (filter && filter.constructor === Array) {
     return filter.map(f => `${convertObjectToString(f)}`).join('|');
   }
-  if (filter.constructor === Object) {
+  if (filter && filter.constructor === Object) {
     const filterArray = [];
     if (filter.SIV_ATTRIBUTE) {
       const filterStringArray = flatten(

--- a/package-lock.json
+++ b/package-lock.json
@@ -3389,6 +3389,12 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "faker": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.2.0.tgz",
+      "integrity": "sha512-UlrF1NNRIdzEPtBcy5l8JTlnXQZdz+4pQc3v2TAVocW39nnczCNQ0g0CBKgPGISJPzA2DqJVN1kdr+FCRFdN5g==",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-config-airbnb": "^17.1.1",
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-plugin-import": "^2.18.0",
+    "faker": "^5.2.0",
     "jest": "^24.8.0",
     "jsdoc-to-markdown": "^5.0.0",
     "rollup": "^1.15.3",

--- a/test/object-to-string.test.js
+++ b/test/object-to-string.test.js
@@ -86,8 +86,8 @@ describe('Invalid inputs', () => {
     ${randomString} | ${''}
     ${[]}           | ${''}
     ${{}}           | ${''}
-    ${undefined}    | ${null}
-    ${null}         | ${null}
+    ${undefined}    | ${''}
+    ${null}         | ${''}
   `('$input returns $expected', ({ input, expected }) => {
     expect(convertObjectToString(input)).toEqual(expected);
   });

--- a/test/object-to-string.test.js
+++ b/test/object-to-string.test.js
@@ -1,0 +1,120 @@
+import convertObjectToString from '../lib/util/object-to-string';
+
+const cat1 = 'Pikachu_1';
+const cat2 = 'Raichu_2';
+const siv1 = 123;
+const siv2 = 214;
+const randomString = 'random string';
+const randomNumber = 42;
+
+describe('Valid inputs', () => {
+  test('SIV included returns correct filter string', () => {
+    const inputObject = {
+      SIV_ATTRIBUTE: {
+        id: { included: [siv1] },
+      },
+    };
+    const expectedOutput = `SIV_ATTRIBUTE(id)==[${siv1}]`;
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('SIVs excluded returns correct filter string', () => {
+    const inputObject = {
+      SIV_ATTRIBUTE: {
+        id: { excluded: [siv1, siv2] },
+      },
+    };
+    const expectedOutput = `SIV_ATTRIBUTE(id)!=[${siv1},${siv2}]`;
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('SIV included, CATEGORY included with subcategories returns correct filter string', () => {
+    const inputObject = [
+      {
+        CATEGORY: {
+          includedWithSubcategories: [cat1],
+        },
+        SIV_ATTRIBUTE: {
+          id: {
+            included: [siv1],
+          },
+        },
+      },
+    ];
+    const expectedOutput = `(SIV_ATTRIBUTE(id)==[${siv1}]&CATEGORY(true)==["${cat1}"])`;
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('SIVs excluded, CATEGORIES included without subcategories returns correct filter string', () => {
+    const inputObject = [
+      {
+        CATEGORY: {
+          includedWithoutSubcategories: [cat1, cat2],
+        },
+        SIV_ATTRIBUTE: {
+          id: {
+            excluded: [siv1, siv2],
+          },
+        },
+      },
+    ];
+    const expectedOutput = `(SIV_ATTRIBUTE(id)!=[${siv1},${siv2}]&CATEGORY(false)==["${cat1}","${cat2}"])`;
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('SIVs included, CATEGORIES excluded with subcategories returns correct filter string', () => {
+    const inputObject = [
+      {
+        CATEGORY: {
+          excludedWithSubcategories: [cat1, cat2],
+        },
+        SIV_ATTRIBUTE: {
+          id: {
+            included: [siv1, siv2],
+          },
+        },
+      },
+    ];
+    const expectedOutput = `(SIV_ATTRIBUTE(id)==[${siv1},${siv2}]&CATEGORY(true)!=["${cat1}","${cat2}"])`;
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+});
+
+describe('Invalid inputs', () => {
+  test('0 returns empty string', () => {
+    const inputObject = 0;
+    const expectedOutput = '';
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('a number returns empty string', () => {
+    const inputObject = randomNumber;
+    const expectedOutput = '';
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('empty string returns empty string', () => {
+    const inputObject = '';
+    const expectedOutput = '';
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('a string returns empty string', () => {
+    const inputObject = randomString;
+    const expectedOutput = '';
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('empty array returns empty string', () => {
+    const inputObject = [];
+    const expectedOutput = '';
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('empty object returns empty string', () => {
+    const inputObject = {};
+    const expectedOutput = '';
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('undefined returns null', () => {
+    const inputObject = undefined;
+    const expectedOutput = null;
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+  test('null returns null', () => {
+    const inputObject = null;
+    const expectedOutput = null;
+    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  });
+});

--- a/test/object-to-string.test.js
+++ b/test/object-to-string.test.js
@@ -1,11 +1,12 @@
+import faker from 'faker';
 import convertObjectToString from '../lib/util/object-to-string';
 
 const cat1 = 'Pikachu_1';
 const cat2 = 'Raichu_2';
 const siv1 = 123;
 const siv2 = 214;
-const randomString = 'random string';
-const randomNumber = 42;
+const randomString = faker.lorem.words();
+const randomNumber = faker.random.number();
 
 describe('Valid inputs', () => {
   test('SIV included returns correct filter string', () => {
@@ -77,44 +78,17 @@ describe('Valid inputs', () => {
 });
 
 describe('Invalid inputs', () => {
-  test('0 returns empty string', () => {
-    const inputObject = 0;
-    const expectedOutput = '';
-    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
-  });
-  test('a number returns empty string', () => {
-    const inputObject = randomNumber;
-    const expectedOutput = '';
-    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
-  });
-  test('empty string returns empty string', () => {
-    const inputObject = '';
-    const expectedOutput = '';
-    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
-  });
-  test('a string returns empty string', () => {
-    const inputObject = randomString;
-    const expectedOutput = '';
-    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
-  });
-  test('empty array returns empty string', () => {
-    const inputObject = [];
-    const expectedOutput = '';
-    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
-  });
-  test('empty object returns empty string', () => {
-    const inputObject = {};
-    const expectedOutput = '';
-    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
-  });
-  test('undefined returns null', () => {
-    const inputObject = undefined;
-    const expectedOutput = null;
-    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
-  });
-  test('null returns null', () => {
-    const inputObject = null;
-    const expectedOutput = null;
-    expect(convertObjectToString(inputObject)).toStrictEqual(expectedOutput);
+  test.each`
+    input           | expected
+    ${0}            | ${''}
+    ${randomNumber} | ${''}
+    ${''}           | ${''}
+    ${randomString} | ${''}
+    ${[]}           | ${''}
+    ${{}}           | ${''}
+    ${undefined}    | ${null}
+    ${null}         | ${null}
+  `('$input returns $expected', ({ input, expected }) => {
+    expect(convertObjectToString(input)).toEqual(expected);
   });
 });

--- a/test/set-filter.test.js
+++ b/test/set-filter.test.js
@@ -222,7 +222,14 @@ describe('Excluding SIV ID', () => {
       subtype: 'id-excluded',
       values: [siv1],
     };
-    const expectedFilterString = null;
+    const expectedFilterString = 'SIV_ATTRIBUTE(id)==[0]';
+    expect(setFilter(filterString, newFilterObject)).toStrictEqual(expectedFilterString);
+  });
+  test('SIV ID - when there is no filter definion and empty filter object', () => {
+    debugger
+    const filterString = '';
+    const newFilterObject = {};
+    const expectedFilterString = 'SIV_ATTRIBUTE(id)==[0]';
     expect(setFilter(filterString, newFilterObject)).toStrictEqual(expectedFilterString);
   });
   test('SIV ID - when it currently does not have an SIV ID attribute excluded but has SIV ID included', () => {

--- a/test/set-filter.test.js
+++ b/test/set-filter.test.js
@@ -215,7 +215,16 @@ describe('Excluding SIV ID', () => {
     const expectedFilterString = `SIV_ATTRIBUTE(id)==[${siv2},${siv3}]`;
     expect(setFilter(filterString, newFilterObject)).toStrictEqual(expectedFilterString);
   });
-
+  test('SIV ID - when it only has one SIV ID and it is removed', () => {
+    const filterString = `SIV_ATTRIBUTE(id)==[${siv1}]`;
+    const newFilterObject = {
+      label: 'SIV',
+      subtype: 'id-excluded',
+      values: [siv1],
+    };
+    const expectedFilterString = null;
+    expect(setFilter(filterString, newFilterObject)).toStrictEqual(expectedFilterString);
+  });
   test('SIV ID - when it currently does not have an SIV ID attribute excluded but has SIV ID included', () => {
     const filterString = `SIV_ATTRIBUTE(id)==[${siv1}]`;
     const newFilterObject = {


### PR DESCRIPTION
In pangea, we ran into an issue when the last remaining item in a category could not be removed (https://rewardops.atlassian.net/browse/PAN-5629 - Scenario 3). There was an error in the console `e is null`. Investigation in filter parser showed the `convertObjectToString` method could not read `constructor` of `null` in this particular case.

~~I think returning `null` from `convertObjectToString` when input is `null` is probably the safest way to handle this. If we return empty string for `null` input, it can resolve in filter definition `''` which returns all SIVs in this case.~~

Testing instructions: All tests should pass.

Update: We don't want to return `null` from `convertObjectToString` - the type of return value should be consistent (string). Instead, we will return default empty filter `'SIV_ATTRIBUTE(id)==[0]'` when `setFilter` would otherwise send `null` to `convertObjectToString`.   